### PR TITLE
remove references to 'prefs:root=' non-public URL scheme that we are …

### DIFF
--- a/ios/RTCSystemSetting.m
+++ b/ios/RTCSystemSetting.m
@@ -40,11 +40,7 @@
 
 -(void)initSetting{
     BOOL newSys = [UIDevice currentDevice].systemVersion.doubleValue >= 10.0;
-    setting = @{@"wifi": (newSys?@"App-Prefs:root=WIFI" : @"prefs:root=WIFI"),
-                @"location": (newSys?@"App-Prefs:root=Privacy&path=LOCATION" : @"prefs:root=Privacy&path=LOCATION"),
-                @"bluetooth": (newSys?@"App-Prefs:root=Bluetooth" : @"prefs:root=Bluetooth"),
-                @"airplane": (newSys?@"App-Prefs:root=AIRPLANE_MODE" : @"prefs:root=AIRPLANE_MODE")
-                };
+    setting = @{};
 }
 
 RCT_EXPORT_MODULE();


### PR DESCRIPTION
remove references to 'prefs:root=' non-public URL scheme that we are not using

```
From Apple
2. 5 Performance: Software Requirements
Guideline 2.5.1 - Performance - Software Requirements


Your app uses the "prefs:root=" non-public URL scheme, which is a private entity. The use of non-public APIs is not permitted on the App Store because it can lead to a poor user experience should these APIs change.

Continuing to use or conceal non-public APIs in future submissions of this app may result in the termination of your Apple Developer account, as well as removal of all associated apps from the App Store.

Next Steps

To resolve this issue, please revise your app to provide the associated functionality using public APIs or remove the functionality using the "prefs:root" or "App-Prefs:root" URL scheme.

If there are no alternatives for providing the functionality your app requires, you can file an enhancement request.
```